### PR TITLE
Smile 723 alarm lambdas

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -522,6 +522,54 @@ Resources:
         PredefinedMetricSpecification:
           PredefinedMetricType: LambdaProvisionedConcurrencyUtilization
 
+  UpdateContentsApiFunctionAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "UpdateContentsApiFunctionAlarm-${AWS::StackName}"
+      AlarmDescription: 'Error in function.'
+      Namespace: AWS/Lambda
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref UpdateContentsApiFunction
+      MetricName: Errors
+      Statistic: Sum
+      Period: 300 #5 minutes
+      EvaluationPeriods: 1
+      Threshold: 0
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+      AlarmActions:
+        - !Ref UpdateContentsApiFunctionAlarmNotification
+
+  UpdateContentsApiFunctionAlarmNotification:
+    Type: AWS::SNS::Topic
+    Properties:
+      TopicName: !Sub "UpdateContentsApiFunctionAlarmNotification-${AWS::StackName}"
+
+  GetContentsApiFunctionAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "GetContentsApiFunctionAlarm-${AWS::StackName}"
+      AlarmDescription: 'Error in function.'
+      Namespace: AWS/Lambda
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref GetContentsApiFunction
+      MetricName: Errors
+      Statistic: Sum
+      Period: 600 #10 minutes
+      EvaluationPeriods: 1
+      Threshold: 0
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+      AlarmActions:
+        - !Ref GetContentsApiFunctionAlarmNotification
+
+  GetContentsApiFunctionAlarmNotification:
+    Type: AWS::SNS::Topic
+    Properties:
+      TopicName: !Sub "GetContentsApiFunctionAlarmNotification-${AWS::StackName}"
+
   ContentsBasePathMapping:
     Type: AWS::ApiGateway::BasePathMapping
     Condition: HasDomainName

--- a/template.yaml
+++ b/template.yaml
@@ -533,7 +533,7 @@ Resources:
           Value: !Ref UpdateContentsApiFunction
       MetricName: Errors
       Statistic: Sum
-      Period: 300 #5 minutes
+      Period: 600 #10 minutes
       EvaluationPeriods: 1
       Threshold: 0
       ComparisonOperator: GreaterThanThreshold


### PR DESCRIPTION
Lagt inn alarmer og tilhørende sns-topics i template.

Legge til og endre epost-varsling etc. på sns-topic'ene gjøres kjapt manuelt inne i AWS.

Justering av grenseverdiene på alarmer må vi finne ut over tid, men disse kan også kjapt endres inne i AWS frem til vi finner gode verdier, også kan vi deretter legge disse inn i template.

Jeg har ikke klusset med stacken i sandbox for å teste template, men tror det er kjappest å rette evt. små feil rett i develop dersom pipeline feiler.